### PR TITLE
add task to remove apache2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+  - name: Remove Apache2
+    become: yes
+    apt: name=apache2 state=absent
+
   - name: add nginx official repo apt list file
     template: src=nginx.list.j2 dest=/etc/apt/sources.list.d/nginx.list mode=0644
     register: official_repo_added


### PR DESCRIPTION
nginx service would fail to start as a result of failing to bind a required address